### PR TITLE
Fix: Add our switch statement convention (avoid default)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -909,22 +909,22 @@ When at all possible, avoid using the `default` clause in `switch` statements, i
 **Preferred:**
 ```swift
 switch someDirection {
-    case west:
-        print("Go west, young man!")
-    case north,
-        south, 
-        east: 
-        print("Go somehere else!")
+case west:
+    print("Go west, young man!")
+case north,
+     south,
+     east:
+    print("Go somehere else!")
 }
 ```
 
 **Not Preferred**
 ```swift
 switch someDirection {
-    case west:
-        print("Go west, young man!")
-    default:
-        print("Go somewhere else")
+case west:
+    print("Go west, young man!")
+default:
+    print("Go somewhere else")
 }
 
 ```
@@ -934,17 +934,17 @@ A more complex exmaple may illustrate the rationale more clearly. Take the case 
 ```swift
 public static func == (lhs: Direction, rhs: Direction) -> Bool {
     switch (lhs, rhs) {
-        case (.north, .north),
-            (.west, .west),
-            (.south, .south),
-            (.east, .east):
-            return true
-            
-        case (.north, _),
-            (.west, _),
-            (.south, _),
-            (.east, _):
-            return false
+    case (.north, .north),
+         (.west, .west),
+         (.south, .south),
+         (.east, .east):
+        return true
+
+    case (.north, _),
+         (.west, _),
+         (.south, _),
+         (.east, _):
+        return false
     }
 }
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -904,7 +904,7 @@ Guard statements are required to exit in some way. Generally, this should be sim
 
 ### Switch Statements
 
-When at all possible, avoid using the `default` clause in `switch` statements, instead prefer to explicitly enumerate the unexpected conditions. The rationale being if a new `case` is added, for example, an `enum`, we want the compiler to generate an error informing us of the unhandled case. If we used a `default` clause, the new case would fall through to that clause and that default action may not be how that case should be handled.
+When at all possible, avoid using the `default` clause in `switch` statements, instead prefer to explicitly enumerate the unexpected conditions. This is especially true with `enum` data types. The rationale being if a new `case` is added to an `enum`, we want the compiler to generate an error informing us of the unhandled case. If we used a `default` clause, the new case would fall through to that clause and that default action may not be how that case should be handled.
 
 **Preferred:**
 ```swift
@@ -950,6 +950,8 @@ public static func == (lhs: Direction, rhs: Direction) -> Bool {
 ```
 
 Were we to add a new cases for in between directions (e.g. `northEast`) and we relied on the `default` clause to inform us of the non-equal state, then `northEast == south` which isn't true, and neither would the compiler inform us of this condition.
+
+Using the `default` clause may be acceptable when switching over other data types.
 
 
 ## Thread Safety Using `mt_` Hungarian Notation

--- a/README.markdown
+++ b/README.markdown
@@ -902,6 +902,54 @@ if let number1 = number1 {
 
 Guard statements are required to exit in some way. Generally, this should be simple one line statement such as `return`, `throw`, `break`, `continue`, and `fatalError()`. Large code blocks should be avoided. If cleanup code is required for multiple exit points, consider using a `defer` block to avoid cleanup code duplication.
 
+### Switch Statements
+
+When at all possible, avoid using the `default` clause in `switch` statements, instead prefer to explicitly enumerate the unexpected conditions. The rationale being if a new `case` is added, for example, an `enum`, we want the compiler to generate an error informing us of the unhandled case. If we used a `default` clause, the new case would fall through to that clause and that default action may not be how that case should be handled.
+
+**Preferred:**
+```swift
+switch someDirection {
+    case west:
+        print("Go west, young man!")
+    case north,
+        south, 
+        east: 
+        print("Go somehere else!")
+}
+```
+
+**Not Preferred**
+```swift
+switch someDirection {
+    case west:
+        print("Go west, young man!")
+    default:
+        print("Go somewhere else")
+}
+
+```
+
+A more complex exmaple may illustrate the rationale more clearly. Take the case of conforming to `Equatable`:
+
+```swift
+public static func == (lhs: Direction, rhs: Direction) -> Bool {
+    switch (lhs, rhs) {
+        case (.north, .north),
+            (.west, .west),
+            (.south, .south),
+            (.east, .east):
+            return true
+            
+        case (.north, _),
+            (.west, _),
+            (.south, _),
+            (.east, _):
+            return false
+    }
+}
+```
+
+
 ## Thread Safety Using `mt_` Hungarian Notation
 Operations that affect the UI should be run on the main thread. Failing to obey this rule results in undefined behavior and untraceable bugs. To mitigate this issue, we use the `mt_` (short for `main thread`) prefix to indicate that something must be accessed from the main thread.
 

--- a/README.markdown
+++ b/README.markdown
@@ -949,6 +949,8 @@ public static func == (lhs: Direction, rhs: Direction) -> Bool {
 }
 ```
 
+Were we to add a new cases for in between directions (e.g. `northEast`) and we relied on the `default` clause to inform us of the non-equal state, then `northEast == south` which isn't true, and neither would the compiler inform us of this condition.
+
 
 ## Thread Safety Using `mt_` Hungarian Notation
 Operations that affect the UI should be run on the main thread. Failing to obey this rule results in undefined behavior and untraceable bugs. To mitigate this issue, we use the `mt_` (short for `main thread`) prefix to indicate that something must be accessed from the main thread.


### PR DESCRIPTION
This situation has come up in a couple of recent pull requests I've reviewed. I noticed that it's missing from our style guide.

